### PR TITLE
Add Graph Coloring Kata (#82)

### DIFF
--- a/GraphColoring/GraphColoring.csproj
+++ b/GraphColoring/GraphColoring.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <PlatformTarget>x64</PlatformTarget>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Quantum.Kata.GraphColoring</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.7.1905.3109" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.7.1905.3109" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.7.1905.3109" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" />
+  </ItemGroup>
+</Project>

--- a/GraphColoring/GraphColoring.sln
+++ b/GraphColoring/GraphColoring.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.645
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GraphColoring", "GraphColoring.csproj", "{79F6EC37-AF54-4CBF-94B6-497703536A06}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{79F6EC37-AF54-4CBF-94B6-497703536A06}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{79F6EC37-AF54-4CBF-94B6-497703536A06}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{79F6EC37-AF54-4CBF-94B6-497703536A06}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{79F6EC37-AF54-4CBF-94B6-497703536A06}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {25683E2F-6DFF-41AF-9748-477003938E13}
+	EndGlobalSection
+EndGlobal

--- a/GraphColoring/README.md
+++ b/GraphColoring/README.md
@@ -1,0 +1,9 @@
+# Welcome!
+
+This kata continues the exploration of the Grover's search algorithm started in the "Grover's Algorithm" kata. 
+It teaches writing oracles for the algorithm which describe the problem instead of the solution, using graph coloring problem as an example. 
+Then it takes the implementation of the Grover's search to the next level, covering solving the problems with unknown number of solutions.
+
+* You can read more about graph coloring problems [here](https://en.wikipedia.org/wiki/Graph_coloring).
+* It is strongly recommended to complete the [Grover's Algorithm kata](./../GroversAlgorithm/) before proceeding to this one. You can also refer to its [README.md](./../GroversAlgorithm/README.md) for the list of resources on Grover's algorithm.
+* [SolveSATWithGrover](./../SolveSATWithGrover/) is another kata covering oracle implementation for solving constraint satisfaction problems.

--- a/GraphColoring/ReferenceImplementation.qs
+++ b/GraphColoring/ReferenceImplementation.qs
@@ -1,0 +1,183 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+//////////////////////////////////////////////////////////////////////
+// This file contains reference solutions to all tasks.
+// The tasks themselves can be found in Tasks.qs file.
+// We recommend that you try to solve the tasks yourself first,
+// but feel free to look up the solution if you get stuck.
+//////////////////////////////////////////////////////////////////////
+
+namespace Quantum.Kata.GraphColoring {
+
+    open Microsoft.Quantum.Arrays;
+    open Microsoft.Quantum.Convert;
+    open Microsoft.Quantum.Math;
+    open Microsoft.Quantum.Measurement;
+    open Microsoft.Quantum.Intrinsic;
+    open Microsoft.Quantum.Canon;
+    open Microsoft.Quantum.Diagnostics;
+
+
+    //////////////////////////////////////////////////////////////////
+    // Part I. Colors representation and manipulation
+    //////////////////////////////////////////////////////////////////
+
+    // Task 1.1. Initialize register to a color
+    operation InitializeColor_Reference (C : Int, register : Qubit[]) : Unit is Adj {
+        let N = Length(register);
+        // Convert C to an array of bits in little endian format
+        let binaryC = IntAsBoolArray(C, N);
+        // Value "true" corresponds to bit 1 and requires applying an X gate
+        ApplyPauliFromBitString(PauliX, true, binaryC, register);
+    }
+
+
+    // Task 1.2. Read color from a register
+    operation MeasureColor_Reference (register : Qubit[]) : Int {
+        return ResultArrayAsInt(MultiM(register));
+    }
+
+
+    // Task 1.3. Read coloring from a register
+    operation MeasureColoring_Reference (K : Int, register : Qubit[]) : Int[] {
+        let N = Length(register) / K;
+        let colorPartitions = Partitioned(ConstantArray(K - 1, N), register);
+        return ForEach(MeasureColor_Reference, colorPartitions);
+    }
+
+
+    // Task 1.4. 2-bit color equality oracle
+    operation ColorEqualityOracle_2bit_Reference (c0 : Qubit[], c1 : Qubit[], target : Qubit) : Unit is Adj+Ctl {
+        // Small case solution with no extra qubits allocated:
+        // iterate over all bit strings of length 2, and do a controlled X on the target qubit
+        // with control qubits c0 and c1 in states described by each of these bit strings.
+        // For a better solution, see task 1.4.
+        for (color in 0..3) {
+            let binaryColor = IntAsBoolArray(color, 2);
+            (ControlledOnBitString(binaryColor + binaryColor, X))(c0 + c1, target);
+        }
+    }
+
+
+    // Task 1.5. N-bit color equality oracle (no extra qubits)
+    operation ColorEqualityOracle_Nbit_Reference (c0 : Qubit[], c1 : Qubit[], target : Qubit) : Unit is Adj+Ctl {
+        for ((q0, q1) in Zip(c0, c1)) {
+            // compute XOR of q0 and q1 in place (storing it in q1)
+            CNOT(q0, q1);
+        }
+        // if all XORs are 0, the bit strings are equal
+        (ControlledOnInt(0, X))(c1, target);
+        // uncompute
+        for ((q0, q1) in Zip(c0, c1)) {
+            CNOT(q0, q1);
+        }
+    }
+
+
+
+    //////////////////////////////////////////////////////////////////
+    // Part II. Vertex coloring problem
+    //////////////////////////////////////////////////////////////////
+
+    // Task 2.1. Classical verification of vertex coloring
+    function IsVertexColoringValid_Reference (V : Int, edges: (Int, Int)[], colors: Int[]) : Bool {
+        for ((start, end) in edges) {
+            if (colors[start] == colors[end]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    // Task 2.2. Oracle for verifying vertex coloring
+    operation VertexColoringOracle_Reference (V : Int, edges : (Int, Int)[], colorsRegister : Qubit[], target : Qubit) : Unit is Adj+Ctl {
+        let nEdges = Length(edges);
+        using (conflicts = Qubit[nEdges]) {
+            for (i in 0 .. nEdges-1) {
+                let (start, end) = edges[i];
+                // Check that endpoints of the edge have different colors:
+                // apply ColorEqualityOracle_Nbit_Reference oracle; if the colors are the same the result will be 1, indicating a conflict
+                ColorEqualityOracle_Nbit_Reference(colorsRegister[start * 2 .. start * 2 + 1], 
+                                                   colorsRegister[end * 2 .. end * 2 + 1], conflicts[i]);
+            }
+
+            // If there are no conflicts (all qubits are in 0 state), the vertex coloring is valid
+            (ControlledOnInt(0, X))(conflicts, target);
+
+            for (i in 0 .. nEdges-1) {
+                let (start, end) = edges[i];
+                // Check that endpoints of the edge have different colors:
+                // apply ColorEqualityOracle_Nbit_Reference oracle; if the colors are the same the result will be 1, indicating a conflict
+                Adjoint ColorEqualityOracle_Nbit_Reference(colorsRegister[start * 2 .. start * 2 + 1], 
+                                                           colorsRegister[end * 2 .. end * 2 + 1], conflicts[i]);
+            }
+        }
+    }
+
+
+    // Task 2.3. Using Grover's search to find vertex coloring
+    operation GroversAlgorithm_Reference (V : Int, oracle : ((Qubit[], Qubit) => Unit is Adj)) : Int[] {
+        // This task is similar to task 2.2 from SolveSATWithGrover kata, but the percentage of correct solutions is potentially higher.
+        mutable coloring = new Int[V];
+
+        // Note that coloring register has the number of qubits that is twice the number of vertices (2 qubits per vertex).
+        using ((register, output) = (Qubit[2 * V], Qubit())) {
+            mutable correct = false;
+            mutable iter = 1;
+            repeat {
+                Message($"Trying search with {iter} iterations");
+                GroversAlgorithm_Loop(register, oracle, iter);
+                let res = MultiM(register);
+                // to check whether the result is correct, apply the oracle to the register plus ancilla after measurement
+                oracle(register, output);
+                if (MResetZ(output) == One) {
+                    set correct = true;
+                    // Read off coloring
+                    set coloring = MeasureColoring_Reference(V, register);
+                }
+                ResetAll(register);
+            } until (correct or iter > 10)  // the fail-safe to avoid going into an infinite loop
+            fixup {
+                set iter += 1;
+            }
+            if (not correct) {
+                fail "Failed to find a coloring";
+            }
+        }
+        return coloring;
+    }
+
+    // Grover loop implementation taken from SolveSATWithGrover kata.
+    operation OracleConverterImpl (markingOracle : ((Qubit[], Qubit) => Unit is Adj), register : Qubit[]) : Unit is Adj {
+
+        using (target = Qubit()) {
+            // Put the target into the |-⟩ state
+            X(target);
+            H(target);
+                
+            // Apply the marking oracle; since the target is in the |-⟩ state,
+            // flipping the target if the register satisfies the oracle condition will apply a -1 factor to the state
+            markingOracle(register, target);
+                
+            // Put the target back into |0⟩ so we can return it
+            H(target);
+            X(target);
+        }
+    }
+    
+    operation GroversAlgorithm_Loop (register : Qubit[], oracle : ((Qubit[], Qubit) => Unit is Adj), iterations : Int) : Unit {
+        let phaseOracle = OracleConverterImpl(oracle, _);
+        ApplyToEach(H, register);
+            
+        for (i in 1 .. iterations) {
+            phaseOracle(register);
+            ApplyToEach(H, register);
+            ApplyToEach(X, register);
+            Controlled Z(Most(register), Tail(register));
+            ApplyToEach(X, register);
+            ApplyToEach(H, register);
+        }
+    }
+}

--- a/GraphColoring/Tasks.qs
+++ b/GraphColoring/Tasks.qs
@@ -1,0 +1,151 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+namespace Quantum.Kata.GraphColoring {
+
+    open Microsoft.Quantum.Diagnostics;
+    open Microsoft.Quantum.Intrinsic;
+    open Microsoft.Quantum.Canon;
+
+    //////////////////////////////////////////////////////////////////
+    // Welcome!
+    //////////////////////////////////////////////////////////////////
+    
+    // The "Graph coloring" quantum kata is a series of exercises designed
+    // to teach you the basics of using Grover search to solve constraint
+    // satisfaction problems, using graph coloring problem as an example.
+    // It covers the following topics:
+    //  - writing oracles implementing constraints on graph coloring,
+    //  - using Grover's algorithm to solve graph coloring problems with unknown number of solutions.
+
+    // Each task is wrapped in one operation preceded by the description of the task.
+    // Each task (except tasks in which you have to write a test) has a unit test associated with it,
+    // which initially fails. Your goal is to fill in the blank (marked with // ... comment)
+    // with some Q# code to make the failing test pass.
+
+    // Within each section, tasks are given in approximate order of increasing difficulty;
+    // harder ones are marked with asterisks.
+
+
+    //////////////////////////////////////////////////////////////////
+    // Part I. Colors representation and manipulation
+    //////////////////////////////////////////////////////////////////
+
+    // Task 1.1. Initialize register to a color
+    // Inputs:
+    //      1) An integer C (0 ≤ C ≤ 2ᴺ - 1).
+    //      2) An array of N qubits in the |0...0⟩ state.
+    // Goal: Prepare the array in the basis state which represents the binary notation of C.
+    //       Use little-endian encoding (i.e., the least significant bit should be stored in the first qubit).
+    // Example: for N = 2 and C = 2 the state should be |01⟩.
+    operation InitializeColor (C : Int, register : Qubit[]) : Unit is Adj {
+        // ...
+    }
+
+
+    // Task 1.2. Read color from a register
+    // Input: An array of N qubits which are guaranteed to be in one of the 2ᴺ basis states.
+    // Output: An N-bit integer that represents this basis state, in little-endian encoding.
+    //         The operation should not change the state of the qubits.
+    // Example: for N = 2 and the qubits in the state |01⟩ return 2 (and keep the qubits in |01⟩).
+    operation MeasureColor (register : Qubit[]) : Int {
+        // ...
+        return -1;
+    }
+
+
+    // Task 1.3. Read coloring from a register
+    // Inputs: 
+    //      1) The number of elements in the coloring K.
+    //      2) An array of K * N qubits which are guaranteed to be in one of the 2ᴷᴺ basis states.
+    // Output: An array of K N-bit integers that represent this basis state. 
+    //         Integer i of the array is stored in qubits i * N, i * N + 1, ..., i * N + N - 1 in little-endian format.
+    //         The operation should not change the state of the qubits.
+    // Example: for N = 2, K = 2 and the qubits in the state |0110⟩ return [2, 1].
+    operation MeasureColoring (K : Int, register : Qubit[]) : Int[] {
+        // ...
+        return new Int[0];
+    }
+
+
+    // Task 1.4. 2-bit color equality oracle
+    // Inputs:
+    //      1) an array of 2 qubits in an arbitrary state |c₀⟩ representing the first color,
+    //      1) an array of 2 qubits in an arbitrary state |c₁⟩ representing the second color,
+    //      3) a qubit in an arbitrary state |y⟩ (target qubit).
+    // Goal: Transform state |c₀⟩|c₁⟩|y⟩ into state |c₀⟩|c₁⟩|y ⊕ f(c₀, c₁)⟩ (⊕ is addition modulo 2),
+    //       where f(x) = 1 if c₀ and c₁ are in the same state, and 0 otherwise.
+    //       Leave the query register in the same state it started in.
+    // In this task you are allowed to allocate extra qubits.
+    operation ColorEqualityOracle_2bit (c0 : Qubit[], c1 : Qubit[], target : Qubit) : Unit is Adj {
+        // ...
+    }
+
+
+    // Task 1.5. N-bit color equality oracle (no extra qubits)
+    // This task is the same as task 1.3, but in this task you are NOT allowed to allocate extra qubits.
+    operation ColorEqualityOracle_Nbit (c0 : Qubit[], c1 : Qubit[], target : Qubit) : Unit is Adj {
+        // ...
+    }
+
+
+
+    //////////////////////////////////////////////////////////////////
+    // Part II. Vertex coloring problem
+    //////////////////////////////////////////////////////////////////
+
+    // Task 2.1. Classical verification of vertex coloring
+    // Inputs:
+    //      1) The number of vertices in the graph V (V ≤ 6).
+    //      2) An array of E tuples of integers, representing the edges of the graph (E ≤ 12).
+    //         Each tuple gives the indices of the start and the end vertices of the edge.
+    //         The vertices are indexed 0 through V - 1.
+    //      3) An array of V integers, representing the vertex coloring of the graph.
+    //         i-th element of the array is the color of the vertex number i.
+    // Output: true if the given vertex coloring is valid 
+    //         (i.e., no pair of vertices connected by an edge have the same color),
+    //         and false otherwise.
+    // Example: Graph 0 -- 1 -- 2 would have V = 3 and edges = [(0, 1), (1, 2)].
+    //         Some of the valid colorings for it would be [0, 1, 0] and [-1, 5, 18].
+    function IsVertexColoringValid (V : Int, edges: (Int, Int)[], colors: Int[]) : Bool {
+        // The following lines enforce the constraints on the input that you are given.
+        // You don't need to modify them. Feel free to remove them, this won't cause your code to fail.
+        Fact(Length(colors) == V, $"The vertex coloring must contain exactly {V} elements, and it contained {Length(colors)}.");
+
+        // ...
+
+        return true;
+    }
+
+
+    // Task 2.2. Oracle for verifying vertex coloring
+    // Inputs:
+    //      1) The number of vertices in the graph V (V ≤ 6).
+    //      2) An array of E tuples of integers, representing the edges of the graph (E ≤ 12).
+    //         Each tuple gives the indices of the start and the end vertices of the edge.
+    //         The vertices are indexed 0 through V - 1.
+    //      3) An array of 2V qubits colorsRegister that encodes the color assignments.
+    //      4) A qubit in an arbitrary state |y⟩ (target qubit).
+    //
+    // Goal: Transform state |x, y⟩ into state |x, y ⊕ f(x)⟩ (⊕ is addition modulo 2),
+    //       where f(x) = 1 the given vertex coloring is valid and 0 otherwise.
+    //       Leave the query register in the same state it started in.
+    //
+    // Each color in colorsRegister is represented as a 2-bit integer in little-endian format.
+    // See task 1.3 for a more detailed description of color assignments.
+    operation VertexColoringOracle (V : Int, edges : (Int, Int)[], colorsRegister : Qubit[], target : Qubit) : Unit is Adj+Ctl {
+        // ...
+    }
+
+
+    // Task 2.3. Using Grover's search to find vertex coloring
+    // Inputs:
+    //      1) The number of vertices in the graph V (V ≤ 6).
+    //      2) A marking oracle which implements vertex coloring verification, as implemented in task 2.2.
+    //
+    // Output: A valid vertex coloring for the graph, in a format used in task 2.1.
+    operation GroversAlgorithm (V : Int, oracle : ((Qubit[], Qubit) => Unit is Adj)) : Int[] {
+        // ...
+        return new Int[V];
+    }
+}

--- a/GraphColoring/TestSuiteRunner.cs
+++ b/GraphColoring/TestSuiteRunner.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+//////////////////////////////////////////////////////////////////////
+// This file contains parts of the testing harness. 
+// You should not modify anything in this file.
+// The tasks themselves can be found in Tasks.qs file.
+//////////////////////////////////////////////////////////////////////
+
+using Microsoft.Quantum.Simulation.XUnit;
+using Microsoft.Quantum.Simulation.Simulators;
+using Xunit.Abstractions;
+using System.Diagnostics;
+
+namespace Quantum.Kata.GraphColoring
+{
+    public class TestSuiteRunner
+    {
+        private readonly ITestOutputHelper output;
+
+        public TestSuiteRunner(ITestOutputHelper output)
+        {
+            this.output = output;
+        }
+
+        /// <summary>
+        /// This driver will run all Q# tests (operations named "...Test") 
+        /// that belong to namespace Quantum.Kata.GraphColoring.
+        /// </summary>
+        [OperationDriver(TestNamespace = "Quantum.Kata.GraphColoring")]
+        public void TestTarget(TestOperation op)
+        {
+            using (var sim = new QuantumSimulator())
+            {
+                // OnLog defines action(s) performed when Q# test calls function Message
+                sim.OnLog += (msg) => { output.WriteLine(msg); };
+                sim.OnLog += (msg) => { Debug.WriteLine(msg); };
+                op.TestOperationRunner(sim);
+            }
+        }
+    }
+}

--- a/GraphColoring/Tests.qs
+++ b/GraphColoring/Tests.qs
@@ -1,0 +1,265 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+//////////////////////////////////////////////////////////////////////
+// This file contains testing harness for all tasks.
+// You should not modify anything in this file.
+// The tasks themselves can be found in Tasks.qs file.
+//////////////////////////////////////////////////////////////////////
+
+namespace Quantum.Kata.GraphColoring {
+    
+    open Microsoft.Quantum.Arrays;
+    open Microsoft.Quantum.Measurement;
+    open Microsoft.Quantum.Intrinsic;
+    open Microsoft.Quantum.Canon;
+    open Microsoft.Quantum.Convert;
+    open Microsoft.Quantum.Math;
+    open Microsoft.Quantum.Diagnostics;
+    
+
+    //////////////////////////////////////////////////////////////////
+    // Part I. Colors representation and manipulation
+    //////////////////////////////////////////////////////////////////
+
+    operation T11_InitializeColor_Test () : Unit {
+        for (N in 1 .. 4) {
+            using (register = Qubit[N]) {
+                for (C in 0 .. (1 <<< N) - 1) {
+                    InitializeColor(C, register);
+                    let measurementResults = MultiM(register);
+                    Fact(ResultArrayAsInt(measurementResults) == C, 
+                        $"Unexpected initialization result for N = {N}, C = {C} : {measurementResults}");
+                    ResetAll(register);
+                }
+            }
+        }
+    }
+
+
+    // ------------------------------------------------------
+    operation T12_MeasureColor_Test () : Unit {
+        for (N in 1 .. 4) {
+            using (register = Qubit[N]) {
+                for (C in 0 .. (1 <<< N) - 1) {
+                    // prepare the register in the input state
+                    InitializeColor_Reference(C, register);
+
+                    // call the solution and verify its return value
+                    let result = MeasureColor(register);
+                    Fact(result == C, $"Unexpected measurement result for N = {N}, C = {C} : {result}");
+
+                    // verify that the register remained in the same state
+                    Adjoint InitializeColor_Reference(C, register);
+                    AssertAllZero(register);
+                }
+            }
+        }
+    }
+
+
+    // ------------------------------------------------------
+    operation T13_MeasureColoring_Test () : Unit {
+        for (K in 1 .. 3) {
+        for (N in 1 .. 3) {
+            using (register = Qubit[N * K]) {
+                for (state in 0 .. (1 <<< (N * K)) - 1) {
+                    // prepare the register in the input state
+                    let binaryState = IntAsBoolArray(state, N * K);
+                    ApplyPauliFromBitString(PauliX, true, binaryState, register);
+
+                    // call the solution
+                    let result = MeasureColoring(K, register);
+
+                    // get the expected coloring by splitting binaryState into parts and converting them into integers
+                    let partitions = Partitioned(ConstantArray(K - 1, N), binaryState);
+                    let expectedColors = ForEach(FunctionAsOperation(BoolArrayAsInt), partitions);
+
+                    // verify the return value
+                    Fact(Length(result) == K, $"Unexpected number of colors for N = {N}, K = {K} : {Length(result)}");
+                    for ((expected, actual) in Zip(expectedColors, result)) {
+                        Fact(expected == actual, $"Unexpected color for N = {N}, K = {K} : expected {expectedColors}, got {result}");
+                    }
+
+                    // verify that the register remained in the same state
+                    ApplyPauliFromBitString(PauliX, true, binaryState, register);
+                    AssertAllZero(register);
+                }
+            }
+        }
+        }
+    }
+
+
+    // ------------------------------------------------------
+    operation CheckColorEqualityOracle (N : Int, oracle : ((Qubit[], Qubit[], Qubit) => Unit)) : Unit {
+        using ((register0, register1, target) = (Qubit[N], Qubit[N], Qubit())) {
+            for (state in 0 .. (1 <<< (2 * N)) - 1) {
+                // prepare the register in the input state
+                InitializeColor_Reference(state, register0 + register1);
+
+                // apply the oracle
+                oracle(register0, register1, target);
+
+                // check that the result is what we'd expect
+                let expectedEquality = (state >>> N) == (state % (1 <<< N));
+                AssertQubit(expectedEquality ? One | Zero, target);
+                Reset(target);
+
+                // verify that the input registers remained in the same state
+                Adjoint InitializeColor_Reference(state, register0 + register1);
+                AssertAllZero(register0);
+                AssertAllZero(register1);
+            }
+        }
+    }
+
+
+    // helper wrapper to represent oracle operation on two input registers of equal size and output register of size 1
+    // as an operation on an array of qubits
+    operation WrapperOperation (op : ((Qubit[], Qubit[], Qubit) => Unit is Adj), qs : Qubit[]) : Unit is Adj {        
+        let N = (Length(qs) - 1) / 2;
+        op(qs[0..N-1], qs[N..2*N-1], qs[2*N]);
+    }
+
+
+    operation T14_ColorEqualityOracle_2bit_Test () : Unit {
+        CheckColorEqualityOracle(2, ColorEqualityOracle_2bit);
+        AssertOperationsEqualReferenced(5, WrapperOperation(ColorEqualityOracle_2bit, _),
+                                           WrapperOperation(ColorEqualityOracle_2bit_Reference, _));
+    }
+
+
+    // ------------------------------------------------------
+    operation T15_ColorEqualityOracle_Nbit_Test () : Unit {
+        for (N in 1..4) {
+            CheckColorEqualityOracle(N, ColorEqualityOracle_Nbit);
+            AssertOperationsEqualReferenced(2*N+1, WrapperOperation(ColorEqualityOracle_Nbit, _),
+                                                   WrapperOperation(ColorEqualityOracle_Nbit_Reference, _));
+            // TODO: verify that the oracle doesn't allocate extra qubits
+        }
+    }
+
+
+
+    //////////////////////////////////////////////////////////////////
+    // Part II. Vertex coloring problem
+    //////////////////////////////////////////////////////////////////
+
+    // Hardcoded graphs used for testing the vertex coloring problem:
+    //  - trivial graph with zero edges
+    //  - complete graph with 4 vertices (4-colorable)
+    //  - disconnected graph
+    //  - random connected graph with more edges and vertices (3-colorable)
+    //  - regular-ish graph with 5 vertices (3-colorable, as shown at https://en.wikipedia.org/wiki/File:3-coloringEx.svg without one vertex)
+    //  - 6-vertex graph from https://en.wikipedia.org/wiki/File:3-coloringEx.svg
+    function ExampleGraphs () : (Int, (Int, Int)[])[] {
+        return [(3, new (Int, Int)[0]),
+                (4, [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)]),
+                (5, [(4, 0), (2, 1), (3, 1), (3, 2)]),
+                (5, [(0, 1), (1, 2), (1, 3), (3, 2), (4, 2), (3, 4)]),
+                (5, [(0, 1), (0, 2), (0, 4), (1, 2), (1, 3), (2, 3), (2, 4), (3, 4)]),
+                (6, [(0, 1), (0, 2), (0, 4), (0, 5), (1, 2), (1, 3), (1, 5), (2, 3), (2, 4), (3, 4), (3, 5), (4, 5)])];
+        // Graphs with 6+ vertices can take several minutes to be processed; 
+        // in the interest of keeping test runtime reasonable we're limiting most of the testing to graphs with 5 vertices or fewer.
+    }
+
+
+    operation T21_IsVertexColoringValid_Test () : Unit {
+        let testCases = ExampleGraphs();
+
+        let (V0, edges0) = testCases[0];
+        Fact(IsVertexColoringValid(V0, edges0, [0, 0, 0]) == true, 
+             $"Coloring [0, 0, 0] judged incorrect for graph V = {V0}, edges = {edges0}");
+        Fact(IsVertexColoringValid(V0, edges0, [2, 1, 3]) == true, 
+             $"Coloring [2, 1, 3] judged incorrect for graph V = {V0}, edges = {edges0}");
+
+        let (V1, edges1) = testCases[1];
+        Fact(IsVertexColoringValid(V1, edges1, [0, 2, 1, 3]) == true, 
+             $"Coloring [0, 2, 1, 3] judged incorrect for graph V = {V1}, edges = {edges1}");
+        Fact(IsVertexColoringValid(V1, edges1, [3, 0, 1, 2]) == true, 
+             $"Coloring [3, 0, 1, 2] judged incorrect for graph V = {V1}, edges = {edges1}");
+        Fact(IsVertexColoringValid(V1, edges1, [0, 2, 1, 0]) == false, 
+             $"Coloring [0, 2, 1, 0] judged correct for graph V = {V1}, edges = {edges1}");
+
+        let (V2, edges2) = testCases[2];
+        // note that in this task the coloring does not have to be limited to numbers 0 .. 3, like in the next task
+        Fact(IsVertexColoringValid(V2, edges2, [0, 1, 2, 3, 4]) == true, 
+             $"Coloring [0, 1, 2, 3, 4] judged incorrect for graph V = {V2}, edges = {edges2}");
+        Fact(IsVertexColoringValid(V2, edges2, [0, 2, 1, 0, 3]) == true, 
+             $"Coloring [0, 2, 1, 0, 3] judged incorrect for graph V = {V2}, edges = {edges2}");
+        Fact(IsVertexColoringValid(V2, edges2, [1, 0, 1, 2, 1]) == false, 
+             $"Coloring [1, 0, 1, 2, 1] judged correct for graph V = {V2}, edges = {edges2}");
+        Fact(IsVertexColoringValid(V2, edges2, [0, 0, 0, 0, 0]) == false, 
+             $"Coloring [0, 0, 0, 0, 0] judged correct for graph V = {V2}, edges = {edges2}");
+
+        let (V3, edges3) = testCases[3];
+        Fact(IsVertexColoringValid(V3, edges3, [0, 1, 0, 2, 1]) == true, 
+             $"Coloring [0, 1, 0, 2, 1] judged incorrect for graph V = {V3}, edges = {edges3}");
+        Fact(IsVertexColoringValid(V3, edges3, [0, 2, 0, 1, 3]) == true, 
+             $"Coloring [0, 2, 0, 1, 3] judged incorrect for graph V = {V3}, edges = {edges3}");
+        Fact(IsVertexColoringValid(V3, edges3, [0, 1, 0, 1, 2]) == false, 
+             $"Coloring [0, 1, 0, 1, 2] judged correct for graph V = {V3}, edges = {edges3}");
+
+        let (V4, edges4) = testCases[4];
+        Fact(IsVertexColoringValid(V4, edges4, [1, 2, 3, 1, 2]) == true, 
+             $"Coloring [1, 2, 3, 1, 2] judged incorrect for graph V = {V4}, edges = {edges4}");
+        Fact(IsVertexColoringValid(V4, edges4, [1, 2, 3, 4, 1]) == false, 
+             $"Coloring [1, 2, 3, 4, 1] judged correct for graph V = {V4}, edges = {edges4}");
+    }
+
+
+    // ------------------------------------------------------
+    operation QubitArrayWrapperOperation (op : ((Qubit[], Qubit) => Unit is Adj), qs : Qubit[]) : Unit is Adj {        
+        op(Most(qs), Tail(qs));
+    }
+
+
+    operation AssertOracleRecognizesColoring (V : Int, edges : (Int, Int)[], oracle : ((Int, (Int, Int)[], Qubit[], Qubit) => Unit)) : Unit {
+        // Message($"Testing V = {V}, edges = {edges}");
+        let N = 2 * V;
+        using ((coloringRegister, target) = (Qubit[N], Qubit())) {
+            // Try all possible colorings of 4 colors on V vertices and check if they are calculated correctly.
+            // Hack: fix the color of the first vertex, since all colorings are agnostic to the specific colors used.
+            for (k in 0 .. (1 <<< (N - 2)) - 1) {
+                // Prepare k-th coloring
+                let binary = [false, false] + IntAsBoolArray(k, N);
+                ApplyPauliFromBitString(PauliX, true, binary, coloringRegister);
+
+                // Read out the coloring (convert one bitmask into V integers) - does not change the state
+                let coloring = MeasureColoring_Reference(V, coloringRegister);
+
+                // Apply the oracle
+                oracle(V, edges, coloringRegister, target);
+
+                // Check that the oracle result matches the classical result
+                let val = IsVertexColoringValid_Reference(V, edges, coloring);
+                // Message($"bitmask = {binary}, coloring = {coloring} - expected answer = {val}");
+                AssertQubit(val ? One | Zero, target);
+                Reset(target);
+
+                // Check that the coloring qubits are still in the same state
+                ApplyPauliFromBitString(PauliX, true, binary, coloringRegister);
+                AssertAllZero(coloringRegister);
+            }
+        }
+    }
+
+
+    operation T22_VertexColoringOracle_Test () : Unit {
+        for ((V, edges) in Most(ExampleGraphs())) {
+            AssertOracleRecognizesColoring(V, edges, VertexColoringOracle);
+        }
+    }
+
+
+    operation T23_GroversAlgorithm_Test () : Unit {
+        for ((V, edges) in ExampleGraphs()) {
+            Message($"Running on graph V = {V}, edges = {edges}");
+            let coloring = GroversAlgorithm(V, VertexColoringOracle_Reference(V, edges, _, _));
+            Fact(IsVertexColoringValid_Reference(V, edges, coloring), 
+                 $"Got incorrect coloring {coloring}");
+            Message($"Got correct coloring {coloring}");
+        }
+    }
+}

--- a/QuantumKatas.code-workspace
+++ b/QuantumKatas.code-workspace
@@ -47,28 +47,32 @@
 			"name": "10. Solving SAT problems using Grover's algorithm"
 		},
 		{
+			"path": "GraphColoring",
+			"name": "11. Solving graph coloring problems using Grover's algorithm"
+		},
+		{
 			"path": "CHSHGame",
-			"name": "11. CHSH game"
+			"name": "12. CHSH game"
 		},
 		{
 			"path": "GHZGame",
-			"name": "12. GHZ game"
+			"name": "13. GHZ game"
 		},
 		{
 			"path": "MagicSquareGame",
-			"name": "13. Mermin-Peres magic square game"
+			"name": "14. Mermin-Peres magic square game"
 		},
 		{
 			"path": "PhaseEstimation",
-			"name": "14. Phase Estimation"
+			"name": "15. Phase Estimation"
 		},
 		{
 			"path": "QEC_BitFlipCode",
-			"name": "15. QEC: Bit-flip Code"
+			"name": "16. QEC: Bit-flip Code"
 		},
 		{
 			"path": "UnitaryPatterns",
-			"name": "16*. Unitary Patterns"
+			"name": "17*. Unitary Patterns"
 		},
 	],
 	"settings": {

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Currently covered topics are:
   This kata introduces Grover's search algorithm and writing quantum oracles to be used with it.
 * **[Solving SAT problems using Grover's algorithm](./SolveSATWithGrover/)**.
   This kata continues the exploration of Grover's search algorithm, using SAT problems as an example. It covers implementing quantum oracles based on the problem description instead of a hard-coded answer and using Grover's algorithm to solve problems with unknown number of solutions.
+* **[Solving graph coloring problems using Grover's algorithm](./GraphColoring/)**.
+  This kata continues the exploration of Grover's search algorithm, using graph coloring problems as an example.
 
 #### Entanglement games
 * **[CHSH game](./CHSHGame/)**.


### PR DESCRIPTION
This adds a Kata exploring using Grover's search to solve the constraint satisfaction problem of graph coloring - coloring nodes of a graph in such a way that no adjacent nodes share the same color.

This project was done as part of UW CSE 490 Q as its final project.
The authors are Dan Tran, Daniel Snitkovskiy, and Frederik Schmitt.

Co-authored-by: Mariia Mykhailova <mamykhai@microsoft.com>